### PR TITLE
26 optimize serialization size

### DIFF
--- a/doc/classDiagram.pu
+++ b/doc/classDiagram.pu
@@ -22,7 +22,7 @@ abstract class SessionLayer {
     {abstract} + virtual rank_t getRankFromRuntimeArgument() const
 }
 abstract class AlgoLayer {
-    - std::vector<std::string> batchMsgsWaitingToBeBroadcast
+    - std::vector<std::string> batchWaitingSessionMsg
     - std::vector<rank_t> broadcastersGroup
     {abstract} + virtual void callbackReceive()
     {abstract} + virtual void callbackInitDone()

--- a/src/AlgoLayer/AlgoLayerMsg.h
+++ b/src/AlgoLayer/AlgoLayerMsg.h
@@ -5,6 +5,7 @@
 #ifndef FBAE_ALGO_LAYER_MSG_H
 #define FBAE_ALGO_LAYER_MSG_H
 
+#include "../adaptCereal.h"
 #include "cereal/archives/binary.hpp"
 #include "cereal/types/string.hpp"
 #include "cereal/types/vector.hpp"

--- a/src/AlgoLayer/AlgoLayerMsg.h
+++ b/src/AlgoLayer/AlgoLayerMsg.h
@@ -10,6 +10,7 @@
 #include "cereal/types/string.hpp"
 #include "cereal/types/vector.hpp"
 #include "../basicTypes.h"
+#include "../SessionLayer/SessionLayerMsg.h"
 
 namespace fbae_AlgoLayer {
 
@@ -18,7 +19,7 @@ namespace fbae_AlgoLayer {
     */
     struct BatchSessionMsg {
         rank_t senderPos{};
-        std::vector<std::string> batchSessionMsg;
+        std::vector<std::shared_ptr<fbaeSL::SessionBaseClass>> batchSessionMsg;
 
         // This method lets cereal know which data members to serialize
         template<class Archive>

--- a/src/AlgoLayer/BBOBB/BBOBB.cpp
+++ b/src/AlgoLayer/BBOBB/BBOBB.cpp
@@ -19,11 +19,11 @@ BBOBB::BBOBB(std::unique_ptr<CommLayer> commLayer)
 {
 }
 
-void BBOBB::callbackReceive(std::string && msgString) {
-    auto msgId{static_cast<MsgId>(msgString[0])};
+void BBOBB::callbackReceive(std::string && algoMsgAsString) {
+    auto msgId{static_cast<MsgId>(algoMsgAsString[0])};
     if (msgId == MsgId::Step) {
         if (!algoTerminated) {
-            auto stepMsg{deserializeStruct<StepMsg>(std::move(msgString))};
+            auto stepMsg{deserializeStruct<StepMsg>(std::move(algoMsgAsString))};
 
             if (getSessionLayer()->getArguments().getVerbose())
                 cout << "\tBBOOBBAlgoLayer / Broadcaster #" << static_cast<uint32_t>(getPosInBroadcastersGroup().value())
@@ -121,7 +121,7 @@ void BBOBB::catchUpIfLateInMessageSending() {
             if (pos != not_found) {
                 auto senderRank = batches[pos].senderPos;
                 for (auto & msg : batches[pos].batchSessionMsg) {
-                    batchNoDeadlockCallbackDeliver(senderRank, std::move(msg));
+                    batchNoDeadlockCallbackDeliver(senderRank, msg);
                     if (algoTerminated) {
                         return;
                     }

--- a/src/AlgoLayer/BBOBB/BBOBB.cpp
+++ b/src/AlgoLayer/BBOBB/BBOBB.cpp
@@ -27,8 +27,8 @@ void BBOBB::callbackReceive(std::string && msgString) {
 
             if (getSessionLayer()->getArguments().getVerbose())
                 cout << "\tBBOOBBAlgoLayer / Broadcaster #" << static_cast<uint32_t>(getPosInBroadcastersGroup().value())
-                     << " : Receive a Step Message (wave : " << stepMsg.wave << " / step : "
-                     << stepMsg.step << ") from Broadcaster #" << static_cast<uint32_t>(stepMsg.senderPos) << "\n";
+                     << " : Receive a Step Message (wave : " << static_cast<uint32_t>(stepMsg.wave) << " / step : "
+                     << static_cast<uint32_t>(stepMsg.step) << ") from Broadcaster #" << static_cast<uint32_t>(stepMsg.senderPos) << "\n";
 
             if (stepMsg.wave == lastSentStepMsg.wave) {
                 currentWaveReceivedStepMsg[stepMsg.step] = stepMsg;
@@ -41,8 +41,8 @@ void BBOBB::callbackReceive(std::string && msgString) {
                 nextWaveReceivedStepMsg[stepMsg.step] = stepMsg;
             } else {
                 cerr << "\tERROR\tBBOBBAlgoLayer/ Broadcaster #" << static_cast<uint32_t>(getPosInBroadcastersGroup().value())
-                     << " (currentWave = " << lastSentStepMsg.wave << ") : Unexpected wave = " << stepMsg.wave
-                     << " (with step = " << stepMsg.step << ") from Broadcaster #"
+                     << " (currentWave = " << static_cast<uint32_t>(lastSentStepMsg.wave) << ") : Unexpected wave = " << static_cast<uint32_t>(stepMsg.wave)
+                     << " (with step = " << static_cast<uint32_t>(stepMsg.step) << ") from Broadcaster #"
                      << static_cast<uint32_t>(stepMsg.senderPos) << "\n";
                 exit(EXIT_FAILURE);
             }
@@ -74,7 +74,7 @@ void BBOBB::beginWave() {
     // Send it
     if (getSessionLayer()->getArguments().getVerbose())
         cout << "\tBBOOBBAlgoLayer / Broadcaster #" << static_cast<uint32_t>(getPosInBroadcastersGroup().value())
-             << " : Send Step Message (wave : " << lastSentStepMsg.wave << " / step : 0) to Broadcaster #" << static_cast<uint32_t>(peersPos[lastSentStepMsg.step])
+             << " : Send Step Message (wave : " << static_cast<uint32_t>(lastSentStepMsg.wave) << " / step : 0) to Broadcaster #" << static_cast<uint32_t>(peersPos[lastSentStepMsg.step])
              << "\n";
     getCommLayer()->send(peersPos[lastSentStepMsg.step],
                                             serializeStruct(lastSentStepMsg));
@@ -91,7 +91,7 @@ void BBOBB::catchUpIfLateInMessageSending() {
         // Send it
         if (getSessionLayer()->getArguments().getVerbose())
             cout << "\tBBOOBBAlgoLayer / Broadcaster #" << static_cast<uint32_t>(getPosInBroadcastersGroup().value())
-                 << " : Send Step Message (wave : " << lastSentStepMsg.wave << " / step : " << lastSentStepMsg.step
+                 << " : Send Step Message (wave : " << static_cast<uint32_t>(lastSentStepMsg.wave) << " / step : " << static_cast<uint32_t>(lastSentStepMsg.step)
                  << ") to Broadcaster #" << static_cast<uint32_t>(peersPos[lastSentStepMsg.step]) << "\n";
         getCommLayer()->send(peersPos[lastSentStepMsg.step],
                                                 serializeStruct(lastSentStepMsg));

--- a/src/AlgoLayer/BBOBB/BBOBB.h
+++ b/src/AlgoLayer/BBOBB/BBOBB.h
@@ -17,7 +17,7 @@
 class BBOBB : public AlgoLayer {
 public :
     explicit BBOBB(std::unique_ptr<CommLayer> commLayer);
-    void callbackReceive(std::string && msgString) override;
+    void callbackReceive(std::string && algoMsgAsString) override;
     void callbackInitDone() override;
     void execute() override;
     void terminate() override;

--- a/src/AlgoLayer/BBOBB/BBOBBMsg.h
+++ b/src/AlgoLayer/BBOBB/BBOBBMsg.h
@@ -22,8 +22,8 @@ namespace fbae_BBOBBAlgoLayer {
     struct StepMsg {
         MsgId msgId{};
         rank_t senderPos{};
-        int wave;
-        int step;
+        uint8_t wave;
+        uint8_t step;
         std::vector<fbae_AlgoLayer::BatchSessionMsg> batchesBroadcast;
 
         // This method lets cereal know which data members to serialize

--- a/src/AlgoLayer/BBOBB/BBOBBMsg.h
+++ b/src/AlgoLayer/BBOBB/BBOBBMsg.h
@@ -1,6 +1,7 @@
 #ifndef FBAE_BBOBBMSG_H
 #define FBAE_BBOBBMSG_H
 
+#include "../../adaptCereal.h"
 #include "cereal/archives/binary.hpp"
 #include "cereal/types/string.hpp"
 #include "cereal/types/vector.hpp"

--- a/src/AlgoLayer/Sequencer/Sequencer.cpp
+++ b/src/AlgoLayer/Sequencer/Sequencer.cpp
@@ -13,9 +13,9 @@ Sequencer::Sequencer(std::unique_ptr<CommLayer> commLayer)
 {
 }
 
-void Sequencer::callbackReceive(std::string && msgString)
+void Sequencer::callbackReceive(std::string && algoMsgAsString)
 {
-    auto msgId{ static_cast<MsgId>(msgString[0]) };
+    auto msgId{ static_cast<MsgId>(algoMsgAsString[0]) };
     switch (msgId)
     {
         using enum MsgId;
@@ -24,7 +24,7 @@ void Sequencer::callbackReceive(std::string && msgString)
         //
         case BroadcastRequest :
         {
-            auto msgToBroadcast{deserializeStruct<StructBroadcastMessage>(std::move(msgString))};
+            auto msgToBroadcast{deserializeStruct<StructBroadcastMessage>(std::move(algoMsgAsString))};
             auto s {serializeStruct<StructBroadcastMessage>(StructBroadcastMessage{MsgId::Broadcast,
                                                                                    msgToBroadcast.senderPos,
                                                                                    msgToBroadcast.sessionMsg})};
@@ -36,7 +36,7 @@ void Sequencer::callbackReceive(std::string && msgString)
         //
         case Broadcast :
         {
-            auto sbm {deserializeStruct<StructBroadcastMessage>(std::move(msgString))};
+            auto sbm {deserializeStruct<StructBroadcastMessage>(std::move(algoMsgAsString))};
             getSessionLayer()->callbackDeliver(sbm.senderPos, std::move(sbm.sessionMsg));
             break;
         }
@@ -86,10 +86,10 @@ std::string Sequencer::toString() {
     return "Sequencer";
 }
 
-void Sequencer::totalOrderBroadcast(std::string && msg) {
+void Sequencer::totalOrderBroadcast(const fbaeSL::SessionMsg &sessionMsg) {
     // Send BroadcastRequest to sequencer
     auto s {serializeStruct<StructBroadcastMessage>(StructBroadcastMessage{MsgId::BroadcastRequest,
                                                                            getPosInBroadcastersGroup().value(),
-                                                                           std::move(msg)})};
+                                                                           sessionMsg})};
     getCommLayer()->send(sequencerRank, s);
 }

--- a/src/AlgoLayer/Sequencer/Sequencer.h
+++ b/src/AlgoLayer/Sequencer/Sequencer.h
@@ -10,9 +10,9 @@ constexpr static rank_t sequencerRank{0};
 class Sequencer : public AlgoLayer {
 public:
     explicit Sequencer(std::unique_ptr<CommLayer> commLayer);
-    void callbackReceive(std::string && msgString) override;
+    void callbackReceive(std::string && algoMsgAsString) override;
     void execute() override;
-    void totalOrderBroadcast(std::string && msg) override;
+    void totalOrderBroadcast(const fbaeSL::SessionMsg &sessionMsg) override;
     void terminate() override;
     std::string toString() override;
 };

--- a/src/AlgoLayer/Sequencer/SequencerMsg.h
+++ b/src/AlgoLayer/Sequencer/SequencerMsg.h
@@ -4,6 +4,7 @@
 #include "cereal/archives/binary.hpp"
 #include "cereal/types/string.hpp"
 #include "../../basicTypes.h"
+#include "../../SessionLayer/SessionLayerMsg.h"
 
 namespace fbae_SequencerAlgoLayer
 {
@@ -23,7 +24,7 @@ namespace fbae_SequencerAlgoLayer
     {
         MsgId msgId{};
         rank_t senderPos{};
-        std::string sessionMsg;
+        std::shared_ptr<fbaeSL::SessionBaseClass> sessionMsg;
 
         // This method lets cereal know which data members to serialize
         template<class Archive>

--- a/src/AlgoLayer/Sequencer/SequencerMsg.h
+++ b/src/AlgoLayer/Sequencer/SequencerMsg.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../../adaptCereal.h"
 #include "cereal/archives/binary.hpp"
 #include "cereal/types/string.hpp"
 #include "../../basicTypes.h"

--- a/src/Arguments.h
+++ b/src/Arguments.h
@@ -7,7 +7,7 @@
 #include "OptParserExtended.h"
 
 // The following value has been found experimentally when filler field of SenderMessageToBroadcast has size 0
-constexpr int minSizeClientMessageToBroadcast{22};
+constexpr int minSizeClientMessageToBroadcast{18};
 
 // Maximum length of a UDP packet
 constexpr size_t maxLength{65515};

--- a/src/Arguments.h
+++ b/src/Arguments.h
@@ -6,8 +6,9 @@
 #include "basicTypes.h"
 #include "OptParserExtended.h"
 
-// The following value has been found experimentally when filler field of SenderMessageToBroadcast has size 0
-constexpr int minSizeClientMessageToBroadcast{18};
+// The following value has been found experimentally when filler field of SessionPerf has size 0
+// (See TEST(SerializationOverhead, CheckMinSizeClientMessageToBroadcast) in @testSerializationOverhead.cpp
+constexpr int minSizeClientMessageToBroadcast{40};
 
 // Maximum length of a UDP packet
 constexpr size_t maxLength{65515};

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(fbae
         SessionLayer/PerfMeasures/PerfMeasures.cpp
         SessionLayer/PerfMeasures/PerfMeasures.h
         AlgoLayer/AlgoLayerMsg.h
+        adaptCereal.h
 )
 if (WIN32)
   target_link_libraries(fbae PUBLIC ws2_32.lib winmm.lib)

--- a/src/CommLayer/CommLayer.h
+++ b/src/CommLayer/CommLayer.h
@@ -24,11 +24,11 @@ public:
         [[nodiscard]] std::latch &getInitDoneCalled();
 
     /**
-     * @brief Multicast message contained in @msg to all peer which the process connected to (Note: The peers which
+     * @brief Multicast @algoMsgAsString to all peer which the process connected to (Note: The peers which
      * connected to the process are not concerned by this multicast)
-     * @param msg Message to be totalOrderBroadcast
+     * @param algoMsgAsString Message to be totalOrderBroadcast
      */
-    virtual void multicastMsg(const std::string &msg) = 0;
+    virtual void multicastMsg(const std::string &algoMsgAsString) = 0;
 
     /**
      * @brief Open connection to peers (named outgoing peers) which rank is listed in @dest, accepts
@@ -47,11 +47,11 @@ public:
     void setAlgoLayer(AlgoLayer* aAlgoLayer);
 
     /**
-     * @brief Sends @msg to outgoing peer of rank @r.
+     * @brief Sends @algoMsgAsString to outgoing peer of rank @r.
      * @param r Rank of outgoing peer
-     * @param msg Message to send.
+     * @param algoMsgAsString Message to send.
      */
-    virtual void send(rank_t r, const std::string &msg) = 0;
+    virtual void send(rank_t r, const std::string &algoMsgAsString) = 0;
 
     /**
      * @brief CommLayer must close all of its connections

--- a/src/CommLayer/Tcp/Tcp.cpp
+++ b/src/CommLayer/Tcp/Tcp.cpp
@@ -100,10 +100,10 @@ void Tcp::handleIncomingConn(std::unique_ptr<boost::asio::ip::tcp::socket> ptrSo
     }
 }
 
-void Tcp::multicastMsg(const std::string &msg)
+void Tcp::multicastMsg(const std::string &algoMsgAsString)
 {
     for (auto const& [r, sock]: rank2sock) {
-        send(r, msg);
+        send(r, algoMsgAsString);
     }
 }
 
@@ -156,9 +156,9 @@ struct ForLength
     }
 };
 
-void Tcp::send(rank_t r, const std::string &msg) {
+void Tcp::send(rank_t r, const std::string &algoMsgAsString) {
     assert(rank2sock.contains(r));
-    ForLength forLength{msg.length()};
+    ForLength forLength{algoMsgAsString.length()};
     std::stringstream oStream;
     {
         cereal::BinaryOutputArchive oarchive(oStream); // Create an output archive
@@ -166,7 +166,7 @@ void Tcp::send(rank_t r, const std::string &msg) {
     } // archive goes out of scope, ensuring all contents are flushed
 
     auto sWithLength = oStream.str();
-    sWithLength.append(msg);
+    sWithLength.append(algoMsgAsString);
 
     boost::asio::write(*rank2sock[r], boost::asio::buffer(sWithLength));
 }

--- a/src/CommLayer/Tcp/Tcp.h
+++ b/src/CommLayer/Tcp/Tcp.h
@@ -15,9 +15,9 @@
 class Tcp : public CommLayer{
 public:
     Tcp() = default;
-    void multicastMsg(const std::string &msg) override;
+    void multicastMsg(const std::string &algoMsgAsString) override;
     void openDestAndWaitIncomingMsg(std::vector<rank_t> const & dest, size_t nbAwaitedConnections, AlgoLayer *aAlgoLayer) override;
-    void send(rank_t r, const std::string &msg) override;
+    void send(rank_t r, const std::string &algoMsgAsString) override;
     void terminate() override;
     std::string toString() override;
 

--- a/src/SessionLayer/PerfMeasures/PerfMeasures.h
+++ b/src/SessionLayer/PerfMeasures/PerfMeasures.h
@@ -15,7 +15,7 @@ class PerfMeasures : public SessionLayer {
 public:
     PerfMeasures(const Arguments &arguments, rank_t rank, std::unique_ptr<AlgoLayer> algoLayer);
 
-    void callbackDeliver(rank_t senderPos, std::string && msg) override;
+    void callbackDeliver(rank_t senderPos, fbaeSL::SessionMsg msg) override;
     void callbackInitDone() override;
     void execute() override;
 
@@ -47,16 +47,16 @@ private:
     /**
      * @brief Called by @callbackDeliver to process @PerfMeasure message
      * @param senderPos Rank of message sender.
-     * @param msg Message to process.
+     * @param sessionMsg Message to process.
      */
-    void processPerfMeasureMsg(rank_t senderPos, std::string && msg);
+    void processPerfMeasureMsg(rank_t senderPos, const fbaeSL::SessionMsg &sessionMsg);
 
     /**
      * @brief Called by @callbackDeliver to process @PerfMeasure message
      * @param senderPos Rank of message sender.
-     * @param msg Message to process.
+     * @param sessionMsg Message to process.
      */
-    void processPerfResponseMsg(rank_t senderPos, std::string && msg);
+    void processPerfResponseMsg(rank_t senderPos, const fbaeSL::SessionMsg &sessionMsg);
 
     /**
      * @brief Thread to send PerfMessage at @Param::frequency per second.

--- a/src/SessionLayer/SessionLayer.cpp
+++ b/src/SessionLayer/SessionLayer.cpp
@@ -3,8 +3,8 @@
 
 SessionLayer::SessionLayer(const Arguments &arguments, rank_t rank, std::unique_ptr<AlgoLayer> algoLayer)
     : arguments{arguments}
-    , rank{rank}
     , algoLayer{std::move(algoLayer)}
+    , rank{rank}
 {
     this->algoLayer->setSessionLayer(this);
 }

--- a/src/SessionLayer/SessionLayer.h
+++ b/src/SessionLayer/SessionLayer.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include "../basicTypes.h"
-#include "../CommLayer/CommLayer.h"
 #include "../Arguments.h"
+#include "../CommLayer/CommLayer.h"
+#include "SessionLayerMsg.h"
 class AlgoLayer;
 
 class SessionLayer {
@@ -23,7 +24,7 @@ public:
      * @param seqNum Sequence number of @msg.
      * @param msg Message to be delivered.
      */
-    virtual void callbackDeliver(rank_t senderPos, std::string && msg) = 0;
+    virtual void callbackDeliver(rank_t senderPos, fbaeSL::SessionMsg msg) = 0;
 
     /**
      * @brief Callback called by @AlgoLayer when @AlgoLayer is initialized locally.

--- a/src/SessionLayer/SessionLayerMsg.h
+++ b/src/SessionLayer/SessionLayerMsg.h
@@ -1,9 +1,11 @@
 #pragma once
 
+#include "../adaptCereal.h"
 #include "cereal/archives/binary.hpp"
 #include "cereal/types/chrono.hpp"
 #include "cereal/types/string.hpp"
 #include "../basicTypes.h"
+
 
 namespace fbae_SessionLayer {
     //---------------------------------------------------

--- a/src/adaptCereal.h
+++ b/src/adaptCereal.h
@@ -9,12 +9,12 @@
     @copyright GNU Affero General Public License
 
 **/
-#ifndef FBAE_ADAPTCEREAL_H
-#define FBAE_ADAPTCEREAL_H
+#ifndef FBAE_ADAPT_CEREAL_H
+#define FBAE_ADAPT_CEREAL_H
 
 /**
  * @brief By default, Cereal serializes size_t as uint64_t (in include/cereal/macros.hpp) ==> We define it as uint32_t
  * in order to prevent bytes waste in serialization.
  */
 #define CEREAL_SIZE_TYPE uint32_t
-#endif //FBAE_ADAPTCEREAL_H
+#endif //FBAE_ADAPT_CEREAL_H

--- a/src/adaptCereal.h
+++ b/src/adaptCereal.h
@@ -1,0 +1,20 @@
+/**
+
+    @file      adaptCereal.h
+    @brief     Include file to adapt default behaviour of Cereal to FBAE requirements
+    @details   This file is to be included before any file related to Cereal, so that it will change Cereal default
+               behaviour.
+    @author    Michel Simatic
+    @date      2/21/24
+    @copyright GNU Affero General Public License
+
+**/
+#ifndef FBAE_ADAPTCEREAL_H
+#define FBAE_ADAPTCEREAL_H
+
+/**
+ * @brief By default, Cereal serializes size_t as uint64_t (in include/cereal/macros.hpp) ==> We define it as uint32_t
+ * in order to prevent bytes waste in serialization.
+ */
+#define CEREAL_SIZE_TYPE uint32_t
+#endif //FBAE_ADAPTCEREAL_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,10 +50,10 @@ int main(int argc, char* argv[])
             "c:comm communicationLayer_identifier \t Communication layer to be used\n\t\t\t\t\t\tt = TCP",
             "f:frequency number \t [optional] Number of PerfMessage sessionLayer messages which must be sent each second (By default, a PerfMessage is sent when receiving a PerfResponse)",
             "h|help \t Show help message",
-            "m:maxBatchSize size_in_bytes \t [optional] Maximum size of batch of messages (if specified algorithm allows batch of messages; By default, maxBatchSize is unlimited)",
+            "m:maxBatchSize number_of_messages \t [optional] Maximum size of batch of messages (if specified algorithm allows batch of messages; By default, maxBatchSize is unlimited)",
             "n:nbMsg number \t Number of messages to be sent",
             "r:rank rank_number \t Rank of process in site file (if 99, all algorithm participants are executed within threads in current process)",
-            "s:size size_in_bytes \t Size of messages sent by a client (must be in interval [18,65515])",
+            "s:size size_in_bytes \t Size of messages sent by a client (must be in interval [40,65515])",
             "S:site siteFile_name \t Name (including path) of the sites file to be used",
             "v|verbose \t [optional] Verbose display required",
             "w:warmupCooldown number \t [optional] Number in [0,99] representing percentage of PerfMessage sessionLayer messages which will be considered as part of warmup phase or cool down phase and thus will not be measured for ping (By default, percentage is 0%)"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,7 +53,7 @@ int main(int argc, char* argv[])
             "m:maxBatchSize size_in_bytes \t [optional] Maximum size of batch of messages (if specified algorithm allows batch of messages; By default, maxBatchSize is unlimited)",
             "n:nbMsg number \t Number of messages to be sent",
             "r:rank rank_number \t Rank of process in site file (if 99, all algorithm participants are executed within threads in current process)",
-            "s:size size_in_bytes \t Size of messages sent by a client (must be in interval [22,65515])",
+            "s:size size_in_bytes \t Size of messages sent by a client (must be in interval [18,65515])",
             "S:site siteFile_name \t Name (including path) of the sites file to be used",
             "v|verbose \t [optional] Verbose display required",
             "w:warmupCooldown number \t [optional] Number in [0,99] representing percentage of PerfMessage sessionLayer messages which will be considered as part of warmup phase or cool down phase and thus will not be measured for ping (By default, percentage is 0%)"

--- a/src/msgTemplates.h
+++ b/src/msgTemplates.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "adaptCereal.h"
 #include <cereal/archives/binary.hpp>
 #include <cereal/types/string.hpp>
 

--- a/tests/CommLayer/CommStub.cpp
+++ b/tests/CommLayer/CommStub.cpp
@@ -43,4 +43,5 @@ void CommStub::terminate() {
 std::string CommStub::toString() {
     // No sense to call this method in the context of tests.
     assert(false);
+    return "CommStub";
 }

--- a/tests/CommLayer/CommStub.cpp
+++ b/tests/CommLayer/CommStub.cpp
@@ -18,9 +18,9 @@ std::vector<std::pair<rank_t, std::string>> &CommStub::getSent() {
     return sent;
 }
 
-void CommStub::multicastMsg(const std::string &msg) {
+void CommStub::multicastMsg(const std::string &algoMsgAsString) {
     for (auto const rank: connectedDest) {
-        send(rank, msg);
+        send(rank, algoMsgAsString);
     }
 }
 
@@ -31,8 +31,8 @@ void CommStub::openDestAndWaitIncomingMsg(const std::vector<rank_t> &dest, size_
     getAlgoLayer()->callbackInitDone();
 }
 
-void CommStub::send(rank_t r, const std::string &msg) {
-    sent.emplace_back(r, msg);
+void CommStub::send(rank_t r, const std::string &algoMsgAsString) {
+    sent.emplace_back(r, algoMsgAsString);
 }
 
 void CommStub::terminate() {

--- a/tests/CommLayer/CommStub.h
+++ b/tests/CommLayer/CommStub.h
@@ -11,9 +11,9 @@ public:
     [[nodiscard]] std::vector<rank_t> &getConnectedDest();
     [[nodiscard]] size_t getNbAwaitedConnections() const;
     [[nodiscard]] std::vector<std::pair<rank_t, std::string>> &getSent();
-    void multicastMsg(const std::string &msg) override;
+    void multicastMsg(const std::string &algoMsgAsString) override;
     void openDestAndWaitIncomingMsg(std::vector<rank_t> const & dest, size_t aNbAwaitedConnections, AlgoLayer *aAlgoLayer) override;
-    void send(rank_t r, const std::string &msg) override;
+    void send(rank_t r, const std::string &algoMsgAsString) override;
     void terminate() override;
     std::string toString() override;
 private:

--- a/tests/SessionLayer/SessionStub.cpp
+++ b/tests/SessionLayer/SessionStub.cpp
@@ -5,23 +5,22 @@
 #include <cassert>
 #include "SessionStub.h"
 #include "../../src/msgTemplates.h"
-#include "../../src/SessionLayer/SessionLayerMsg.h"
 
 SessionStub::SessionStub(const Arguments &arguments, rank_t rank, std::unique_ptr<AlgoLayer> algoLayer)
         : SessionLayer(arguments, rank, std::move(algoLayer))
 {
 }
 
-void SessionStub::callbackDeliver(rank_t senderPos, std::string &&msg) {
-    delivered.emplace_back(senderPos, std::move(msg));
+void SessionStub::callbackDeliver(rank_t senderPos, fbaeSL::SessionMsg msg) {
+    delivered.emplace_back(senderPos, msg);
 }
 
 void SessionStub::callbackInitDone() {
     callbackInitDoneCalled = true;
     // We simulate the sending fo FirstBroadcast as done in @PerfMeasures class.
     if (getAlgoLayer()->isBroadcastingMessages()) {
-        auto s {serializeStruct<fbae_SessionLayer::SessionFirstBroadcast>(fbae_SessionLayer::SessionFirstBroadcast{fbae_SessionLayer::SessionMsgId::FirstBroadcast})};
-        getAlgoLayer()->totalOrderBroadcast(std::move(s));
+        auto sessionMsg = std::make_shared<fbaeSL::SessionFirstBroadcast>(fbaeSL::SessionMsgId::FirstBroadcast);
+        getAlgoLayer()->totalOrderBroadcast(sessionMsg);
     }
 }
 
@@ -30,10 +29,10 @@ void SessionStub::execute() {
     assert(false);
 }
 
-std::vector<std::pair<rank_t, std::string>> &SessionStub::getDelivered() {
+std::vector<std::pair<rank_t, fbaeSL::SessionMsg>> & SessionStub::getDelivered() {
     return delivered;
 }
 
-bool SessionStub::isCallbackInitdoneCalled() const {
+bool SessionStub::isCallbackInitDoneCalled() const {
     return callbackInitDoneCalled;
 }

--- a/tests/SessionLayer/SessionStub.h
+++ b/tests/SessionLayer/SessionStub.h
@@ -12,16 +12,16 @@ class SessionStub : public SessionLayer {
 public:
     SessionStub(const Arguments &arguments, rank_t rank, std::unique_ptr<AlgoLayer> algoLayer);
 
-    void callbackDeliver(rank_t senderPos, std::string && msg) override;
+    void callbackDeliver(rank_t senderPos, fbaeSL::SessionMsg msg) override;
     void callbackInitDone() override;
     void execute() override;
-    [[nodiscard]] std::vector<std::pair<rank_t, std::string>> &getDelivered();
-    [[nodiscard]] bool isCallbackInitdoneCalled() const;
+    [[nodiscard]] std::vector<std::pair<rank_t, fbaeSL::SessionMsg>> & getDelivered();
+    [[nodiscard]] bool isCallbackInitDoneCalled() const;
 private:
     /**
      * @brief Vector of [sender,msg] for which @callbackDeliver() method was called
      */
-    std::vector<std::pair<rank_t, std::string>> delivered;
+    std::vector<std::pair<rank_t, fbaeSL::SessionMsg>> delivered;
 
     /**
      * @brief Indicates whether @SessionLayer::callbackInitDone called or not.

--- a/tests/testSerializationOverhead.cpp
+++ b/tests/testSerializationOverhead.cpp
@@ -74,7 +74,7 @@ namespace fbae_test_serializationOverhead {
                                                                                                    42,
                                                                                                    55,
                                                                                                    v_batchSessionMsg_11})};
-        constexpr auto sizeHeaderAndSizeVectorEncodingInStepMsg = sizeof(fbae_BBOBBAlgoLayer::MsgId) + sizeof(rank_t) + sizeof(int) + sizeof(int) + sizeof(size_t); // sizeof(size_t) for the encoding of the size of the vector
+        constexpr auto sizeHeaderAndSizeVectorEncodingInStepMsg = sizeof(fbae_BBOBBAlgoLayer::MsgId) + sizeof(rank_t) + sizeof(uint8_t) + sizeof(uint8_t) + sizeof(size_t); // sizeof(size_t) for the encoding of the size of the vector
         EXPECT_EQ(sizeHeaderAndSizeVectorEncodingInStepMsg + nbBatchInStep * (sizeHeaderAndSizeVectorEncodingInBatchSessionMsg + nbSessionMsgPerBatch *(sizeof(size_t) + s_sessionMsg.size())),
                   s_Step_11.size());
     }

--- a/tests/testSerializationOverhead.cpp
+++ b/tests/testSerializationOverhead.cpp
@@ -20,8 +20,8 @@ namespace fbae_test_serializationOverhead {
                                                                                                           string(
                                                                                                                     sizeStringInSessionMsg,
                                                                                                                     'A')})};
-        // Serialization overhead is sizeof(size_t) because Cereal need to store the size of the string.
-        EXPECT_EQ(sizeof(size_t) + sizeof(fbae_SessionLayer::SessionMsgId)+sizeStringInSessionMsg,
+        // Serialization overhead is sizeof(CEREAL_SIZE_TYPE) because Cereal need to store the size of the string.
+        EXPECT_EQ(sizeof(CEREAL_SIZE_TYPE) + sizeof(fbae_SessionLayer::SessionMsgId)+sizeStringInSessionMsg,
                   s_sessionMsg.size());
     }
 
@@ -33,8 +33,8 @@ namespace fbae_test_serializationOverhead {
         auto s_StructBroadcastMessage {serializeStruct<fbae_SequencerAlgoLayer::StructBroadcastMessage>(fbae_SequencerAlgoLayer::StructBroadcastMessage{fbae_SequencerAlgoLayer::MsgId::Broadcast,
                                                                                                                                                         '1',
                                                                                                                                                         s_sessionMsg})};
-        // Serialization overhead is sizeof(fbae_SequencerAlgoLayer::MsgId)+sizeof(senderPos)+sizeof(size_t) (because Cereal need to store the size of the string) + overhead on session message.
-        EXPECT_EQ(sizeof(fbae_SequencerAlgoLayer::MsgId) + sizeof(rank_t) + sizeof(size_t) + (sizeof(size_t) + sizeof(fbae_SessionLayer::SessionMsgId)+sizeStringInSessionMsg),
+        // Serialization overhead is sizeof(fbae_SequencerAlgoLayer::MsgId)+sizeof(senderPos)+sizeof(CEREAL_SIZE_TYPE) (because Cereal need to store the size of the string) + overhead on session message.
+        EXPECT_EQ(sizeof(fbae_SequencerAlgoLayer::MsgId) + sizeof(rank_t) + sizeof(CEREAL_SIZE_TYPE) + (sizeof(CEREAL_SIZE_TYPE) + sizeof(fbae_SessionLayer::SessionMsgId)+sizeStringInSessionMsg),
                   s_StructBroadcastMessage.size());
     }
 
@@ -50,8 +50,8 @@ namespace fbae_test_serializationOverhead {
                 v_11};
         auto s_batchSessionMsg_11 {serializeStruct<fbae_AlgoLayer::BatchSessionMsg>(batchSessionMsg_11)};
 
-        constexpr auto sizeHeaderAndSizeVectorEncodingInBatchSessionMsg = sizeof(fbae_BBOBBAlgoLayer::MsgId) + sizeof(size_t); // sizeof(size_t) for the encoding of the size of the vector
-        EXPECT_EQ(sizeHeaderAndSizeVectorEncodingInBatchSessionMsg + nbSessionMsgPerBatch * (sizeof(size_t) + s_sessionMsg.size()),
+        constexpr auto sizeHeaderAndSizeVectorEncodingInBatchSessionMsg = sizeof(fbae_BBOBBAlgoLayer::MsgId) + sizeof(CEREAL_SIZE_TYPE); // sizeof(CEREAL_SIZE_TYPE) for the encoding of the size of the vector
+        EXPECT_EQ(sizeHeaderAndSizeVectorEncodingInBatchSessionMsg + nbSessionMsgPerBatch * (sizeof(CEREAL_SIZE_TYPE) + s_sessionMsg.size()),
                   s_batchSessionMsg_11.size());
     }
 
@@ -65,7 +65,7 @@ namespace fbae_test_serializationOverhead {
         fbae_AlgoLayer::BatchSessionMsg batchSessionMsg_11 {
                 '1',
                 v_11};
-        constexpr auto sizeHeaderAndSizeVectorEncodingInBatchSessionMsg = sizeof(fbae_BBOBBAlgoLayer::MsgId) + sizeof(size_t); // sizeof(size_t) for the encoding of the size of the vector
+        constexpr auto sizeHeaderAndSizeVectorEncodingInBatchSessionMsg = sizeof(fbae_BBOBBAlgoLayer::MsgId) + sizeof(CEREAL_SIZE_TYPE); // sizeof(CEREAL_SIZE_TYPE) for the encoding of the size of the vector
 
         constexpr auto nbBatchInStep = 1;
         std::vector<fbae_AlgoLayer::BatchSessionMsg> v_batchSessionMsg_11{batchSessionMsg_11};
@@ -74,8 +74,8 @@ namespace fbae_test_serializationOverhead {
                                                                                                    42,
                                                                                                    55,
                                                                                                    v_batchSessionMsg_11})};
-        constexpr auto sizeHeaderAndSizeVectorEncodingInStepMsg = sizeof(fbae_BBOBBAlgoLayer::MsgId) + sizeof(rank_t) + sizeof(uint8_t) + sizeof(uint8_t) + sizeof(size_t); // sizeof(size_t) for the encoding of the size of the vector
-        EXPECT_EQ(sizeHeaderAndSizeVectorEncodingInStepMsg + nbBatchInStep * (sizeHeaderAndSizeVectorEncodingInBatchSessionMsg + nbSessionMsgPerBatch *(sizeof(size_t) + s_sessionMsg.size())),
+        constexpr auto sizeHeaderAndSizeVectorEncodingInStepMsg = sizeof(fbae_BBOBBAlgoLayer::MsgId) + sizeof(rank_t) + sizeof(uint8_t) + sizeof(uint8_t) + sizeof(CEREAL_SIZE_TYPE); // sizeof(CEREAL_SIZE_TYPE) for the encoding of the size of the vector
+        EXPECT_EQ(sizeHeaderAndSizeVectorEncodingInStepMsg + nbBatchInStep * (sizeHeaderAndSizeVectorEncodingInBatchSessionMsg + nbSessionMsgPerBatch *(sizeof(CEREAL_SIZE_TYPE) + s_sessionMsg.size())),
                   s_Step_11.size());
     }
 
@@ -85,7 +85,7 @@ namespace fbae_test_serializationOverhead {
                                                                                                                         0,
                                                                                                                         std::chrono::system_clock::now(),
                                                                                                                         ""})};
-        // Serialization overhead is sizeof(size_t) because Cereal need to store the size of the string.
+        // Serialization overhead is sizeof(CEREAL_SIZE_TYPE) because Cereal need to store the size of the string.
         EXPECT_EQ(minSizeClientMessageToBroadcast,
                   s_sessionMsg.size());
     }

--- a/tests/testSerializationOverhead.cpp
+++ b/tests/testSerializationOverhead.cpp
@@ -1,6 +1,13 @@
-//
-// Created by simatic on 2/5/24.
-//
+/**
+
+    @file      testSerializationOverhead.cpp
+    @brief     Unitary tests related to serialization overhead
+    @details
+    @author    Michel Simatic
+    @date      2/5/24
+    @copyright GNU Affero General Public License
+
+**/
 #include <gtest/gtest.h>
 #include <vector>
 #include "../src/Arguments.h"
@@ -15,57 +22,37 @@ namespace fbae_test_serializationOverhead {
 
     constexpr size_t sizeStringInSessionMsg = 9;
 
-    TEST(SerializationOverhead, SerializedSessionMsg) {
-        auto s_sessionMsg {serializeStruct<fbae_SessionLayer::SessionTest>(fbae_SessionLayer::SessionTest{fbae_SessionLayer::SessionMsgId::TestMessage,
-                                                                                                          string(
-                                                                                                                    sizeStringInSessionMsg,
-                                                                                                                    'A')})};
-        // Serialization overhead is sizeof(CEREAL_SIZE_TYPE) because Cereal need to store the size of the string.
-        EXPECT_EQ(sizeof(CEREAL_SIZE_TYPE) + sizeof(fbae_SessionLayer::SessionMsgId)+sizeStringInSessionMsg,
-                  s_sessionMsg.size());
-    }
+    constexpr size_t overheadCerealPolymorphicEncoding = 22; // This value was determined experimentally
+
+    // sizeOfEncodedSessionMsg is overheadCerealPolymorphicEncoding
+    //                             + sizeof(fbaeSL::SessionMsgId)
+    //                             + sizeof(CEREAL_SIZE_TYPE) (because Cereal need to store the size of the string)
+    //                             + sizeStringInSessionMsg
+    constexpr size_t sizeOfEncodedSessionMsg = overheadCerealPolymorphicEncoding + sizeof(fbaeSL::SessionMsgId) + sizeof(CEREAL_SIZE_TYPE) + sizeStringInSessionMsg;
 
     TEST(SerializationOverhead, SerializedSequencerMsg) {
-        auto s_sessionMsg {serializeStruct<fbae_SessionLayer::SessionTest>(fbae_SessionLayer::SessionTest{fbae_SessionLayer::SessionMsgId::TestMessage,
-                                                                                                          string(
-                                                                                                              sizeStringInSessionMsg,
-                                                                                                              'A')})};
+        auto sessionMsg = make_shared<fbaeSL::ST>(
+                fbaeSL::SessionMsgId::TestMessage,
+                string(sizeStringInSessionMsg,'A')
+                );
         auto s_StructBroadcastMessage {serializeStruct<fbae_SequencerAlgoLayer::StructBroadcastMessage>(fbae_SequencerAlgoLayer::StructBroadcastMessage{fbae_SequencerAlgoLayer::MsgId::Broadcast,
                                                                                                                                                         '1',
-                                                                                                                                                        s_sessionMsg})};
-        // Serialization overhead is sizeof(fbae_SequencerAlgoLayer::MsgId)+sizeof(senderPos)+sizeof(CEREAL_SIZE_TYPE) (because Cereal need to store the size of the string) + overhead on session message.
-        EXPECT_EQ(sizeof(fbae_SequencerAlgoLayer::MsgId) + sizeof(rank_t) + sizeof(CEREAL_SIZE_TYPE) + (sizeof(CEREAL_SIZE_TYPE) + sizeof(fbae_SessionLayer::SessionMsgId)+sizeStringInSessionMsg),
+                                                                                                                                                        sessionMsg})};
+        // Serialization overhead is sizeof(fbae_SequencerAlgoLayer::MsgId)+sizeof(senderPos).
+        EXPECT_EQ(sizeof(fbae_SequencerAlgoLayer::MsgId) + sizeof(rank_t) + sizeOfEncodedSessionMsg,
                   s_StructBroadcastMessage.size());
     }
 
-    TEST(SerializationOverhead, SerializedBatchMsg) {
-        auto s_sessionMsg {serializeStruct<fbae_SessionLayer::SessionTest>(fbae_SessionLayer::SessionTest{fbae_SessionLayer::SessionMsgId::TestMessage,
-                                                                                                          string(
-                                                                                                                                                    sizeStringInSessionMsg,
-                                                                                                                                                    'A')})};
-        constexpr auto nbSessionMsgPerBatch = 1;
-        std::vector<std::string> v_11{s_sessionMsg};
-        fbae_AlgoLayer::BatchSessionMsg batchSessionMsg_11 {
-                '1',
-                v_11};
-        auto s_batchSessionMsg_11 {serializeStruct<fbae_AlgoLayer::BatchSessionMsg>(batchSessionMsg_11)};
-
-        constexpr auto sizeHeaderAndSizeVectorEncodingInBatchSessionMsg = sizeof(fbae_BBOBBAlgoLayer::MsgId) + sizeof(CEREAL_SIZE_TYPE); // sizeof(CEREAL_SIZE_TYPE) for the encoding of the size of the vector
-        EXPECT_EQ(sizeHeaderAndSizeVectorEncodingInBatchSessionMsg + nbSessionMsgPerBatch * (sizeof(CEREAL_SIZE_TYPE) + s_sessionMsg.size()),
-                  s_batchSessionMsg_11.size());
-    }
-
     TEST(SerializationOverhead, SerializedBBOBBStepMsg) {
-        auto s_sessionMsg {serializeStruct<fbae_SessionLayer::SessionTest>(fbae_SessionLayer::SessionTest{fbae_SessionLayer::SessionMsgId::TestMessage,
-                                                                                                          string(
-                                                                                                                                                    sizeStringInSessionMsg,
-                                                                                                                                                    'A')})};
+        auto sessionMsg = make_shared<fbaeSL::ST>(
+                fbaeSL::SessionMsgId::TestMessage,
+                string(sizeStringInSessionMsg,'A')
+        );
         constexpr auto nbSessionMsgPerBatch = 1;
-        std::vector<std::string> v_11{s_sessionMsg};
+        std::vector<std::shared_ptr<fbaeSL::SessionBaseClass>> v_11{sessionMsg};
         fbae_AlgoLayer::BatchSessionMsg batchSessionMsg_11 {
                 '1',
                 v_11};
-        constexpr auto sizeHeaderAndSizeVectorEncodingInBatchSessionMsg = sizeof(fbae_BBOBBAlgoLayer::MsgId) + sizeof(CEREAL_SIZE_TYPE); // sizeof(CEREAL_SIZE_TYPE) for the encoding of the size of the vector
 
         constexpr auto nbBatchInStep = 1;
         std::vector<fbae_AlgoLayer::BatchSessionMsg> v_batchSessionMsg_11{batchSessionMsg_11};
@@ -75,18 +62,21 @@ namespace fbae_test_serializationOverhead {
                                                                                                    55,
                                                                                                    v_batchSessionMsg_11})};
         constexpr auto sizeHeaderAndSizeVectorEncodingInStepMsg = sizeof(fbae_BBOBBAlgoLayer::MsgId) + sizeof(rank_t) + sizeof(uint8_t) + sizeof(uint8_t) + sizeof(CEREAL_SIZE_TYPE); // sizeof(CEREAL_SIZE_TYPE) for the encoding of the size of the vector
-        EXPECT_EQ(sizeHeaderAndSizeVectorEncodingInStepMsg + nbBatchInStep * (sizeHeaderAndSizeVectorEncodingInBatchSessionMsg + nbSessionMsgPerBatch *(sizeof(CEREAL_SIZE_TYPE) + s_sessionMsg.size())),
+        EXPECT_EQ(sizeHeaderAndSizeVectorEncodingInStepMsg + nbBatchInStep * (sizeof(fbae_AlgoLayer::BatchSessionMsg::senderPos) + sizeof(CEREAL_SIZE_TYPE) + nbSessionMsgPerBatch * sizeOfEncodedSessionMsg),
                   s_Step_11.size());
     }
 
     TEST(SerializationOverhead, CheckMinSizeClientMessageToBroadcast) {
-        auto s_sessionMsg {serializeStruct<fbae_SessionLayer::SessionPerfMeasure>(fbae_SessionLayer::SessionPerfMeasure{fbae_SessionLayer::SessionMsgId::PerfMeasure,
-                                                                                                                        0,
-                                                                                                                        0,
-                                                                                                                        std::chrono::system_clock::now(),
-                                                                                                                        ""})};
+        auto sessionPerf = make_shared<fbaeSL::SP>(
+                fbaeSL::SessionMsgId::PerfMeasure,
+                0,
+                0,
+                std::chrono::system_clock::now(),
+                "");
         // Serialization overhead is sizeof(CEREAL_SIZE_TYPE) because Cereal need to store the size of the string.
         EXPECT_EQ(minSizeClientMessageToBroadcast,
-                  s_sessionMsg.size());
+                  overheadCerealPolymorphicEncoding
+                  + sizeof(sessionPerf->msgId) + sizeof(sessionPerf->senderPos) + sizeof(sessionPerf->msgNum)
+                  + sizeof(sessionPerf->sendTime) + sizeof(CEREAL_SIZE_TYPE)); // sizeof(CEREAL_SIZE_TYPE) is used to store the length of empty filler
     }
 }


### PR DESCRIPTION
1. Thanks to adaptCereal.h, in FBAE, Cereal uses only 4 bytes for storing size_t variables (used to store size of string and size of vectors).
2. Use Cereal Polymorphic capabilities:

    - Between SessionLayer and AlgoLayer, session messages are exchanged as SessionMsg type, not std::string like before.
    - In AlgoLayer, callbackHandleMsg() is renamed into callbackReceive().

Open issues introduced by this pull request:

- Current implementation of Cereal Polymorphic has too much overhead (22 bytes, when it should be only 8 bytes according to tests). This is because Cereal stores name of serialized type as a string into the resulting string. For the moment, we do not know why Cereal does that.
- Unitary tests are not found by Visual Studio.
