### PR TITLE
Suppress compilation warnings in SessionLayerMsg.h and reduce overhead of polymorphic serialization from 22 to 13 bytes.

### DIFF
--- a/src/AlgoLayer/AlgoLayer.cpp
+++ b/src/AlgoLayer/AlgoLayer.cpp
@@ -51,7 +51,7 @@ void AlgoLayer::setSessionLayer(SessionLayer *aSessionLayer)
     sessionLayer = aSessionLayer;
 }
 
-void AlgoLayer::batchNoDeadlockCallbackDeliver(rank_t senderPos, std::shared_ptr<fbaeSL::SessionBaseClass> const& msg) {
+void AlgoLayer::batchNoDeadlockCallbackDeliver(rank_t senderPos, std::shared_ptr<fbae_SessionLayer::SessionBaseClass> const& msg) {
     // We surround the call to @callbackDeliver method with shortcutBatchCtrl = true; and
     // shortcutBatchCtrl = false; This is because callbackDeliver() may lead to a call to
     // @totalOrderBroadcast method which could get stuck in condVarBatchCtrl.wait() instruction
@@ -75,7 +75,7 @@ fbae_AlgoLayer::BatchSessionMsg AlgoLayer::batchGetBatchMsgs(rank_t senderPos) {
     return msg;
 }
 
-void AlgoLayer::totalOrderBroadcast(const fbaeSL::SessionMsg &sessionMsg) {
+void AlgoLayer::totalOrderBroadcast(const fbae_SessionLayer::SessionMsg &sessionMsg) {
     unique_lock lck(batchCtrlMtx);
     batchCtrlCondVar.wait(lck, [this] {
         return (batchWaitingSessionMsg.size() < getSessionLayer()->getArguments().getMaxBatchSize())

--- a/src/AlgoLayer/AlgoLayer.h
+++ b/src/AlgoLayer/AlgoLayer.h
@@ -26,7 +26,7 @@ public:
      * @param senderPos Position of @msg sender in @AlgoLayer::broadcasters.
      * @param msg Message to be delivered.
      */
-    void batchNoDeadlockCallbackDeliver(rank_t senderPos, std::shared_ptr<fbaeSL::SessionBaseClass> const& msg);
+    void batchNoDeadlockCallbackDeliver(rank_t senderPos, std::shared_ptr<fbae_SessionLayer::SessionBaseClass> const& msg);
 
     /**
      * @brief Register that current thread accepts that it is not concerned by value of @batchCtrlShortcut
@@ -99,7 +99,7 @@ public:
      * @batchWaitingSessionMsg
      * @param sessionMsg Message to totally-order totalOrderBroadcast.
      */
-    virtual void totalOrderBroadcast(const fbaeSL::SessionMsg &sessionMsg);
+    virtual void totalOrderBroadcast(const fbae_SessionLayer::SessionMsg &sessionMsg);
 
     /**
      * @brief Terminates execution of concrete totalOrderBroadcast algorithm. Eventually this call will lead to the
@@ -144,7 +144,7 @@ private:
     /**
      * @brief PerfMeasures messages waiting to be broadcast.
      */
-    std::vector<fbaeSL::SessionMsg> batchWaitingSessionMsg;
+    std::vector<fbae_SessionLayer::SessionMsg> batchWaitingSessionMsg;
 
     /**
      * @brief Rank of @sites which are indeed doing broadcasts.

--- a/src/AlgoLayer/AlgoLayerMsg.h
+++ b/src/AlgoLayer/AlgoLayerMsg.h
@@ -7,7 +7,6 @@
 
 #include "../adaptCereal.h"
 #include "cereal/archives/binary.hpp"
-#include "cereal/types/string.hpp"
 #include "cereal/types/vector.hpp"
 #include "../basicTypes.h"
 #include "../SessionLayer/SessionLayerMsg.h"
@@ -19,7 +18,7 @@ namespace fbae_AlgoLayer {
     */
     struct BatchSessionMsg {
         rank_t senderPos{};
-        std::vector<std::shared_ptr<fbaeSL::SessionBaseClass>> batchSessionMsg;
+        std::vector<fbae_SessionLayer::SessionMsg> batchSessionMsg;
 
         // This method lets cereal know which data members to serialize
         template<class Archive>

--- a/src/AlgoLayer/BBOBB/BBOBBMsg.h
+++ b/src/AlgoLayer/BBOBB/BBOBBMsg.h
@@ -3,7 +3,6 @@
 
 #include "../../adaptCereal.h"
 #include "cereal/archives/binary.hpp"
-#include "cereal/types/string.hpp"
 #include "cereal/types/vector.hpp"
 #include "../../basicTypes.h"
 #include "../AlgoLayerMsg.h"

--- a/src/AlgoLayer/Sequencer/Sequencer.cpp
+++ b/src/AlgoLayer/Sequencer/Sequencer.cpp
@@ -86,7 +86,7 @@ std::string Sequencer::toString() {
     return "Sequencer";
 }
 
-void Sequencer::totalOrderBroadcast(const fbaeSL::SessionMsg &sessionMsg) {
+void Sequencer::totalOrderBroadcast(const fbae_SessionLayer::SessionMsg &sessionMsg) {
     // Send BroadcastRequest to sequencer
     auto s {serializeStruct<StructBroadcastMessage>(StructBroadcastMessage{MsgId::BroadcastRequest,
                                                                            getPosInBroadcastersGroup().value(),

--- a/src/AlgoLayer/Sequencer/Sequencer.h
+++ b/src/AlgoLayer/Sequencer/Sequencer.h
@@ -12,7 +12,7 @@ public:
     explicit Sequencer(std::unique_ptr<CommLayer> commLayer);
     void callbackReceive(std::string && algoMsgAsString) override;
     void execute() override;
-    void totalOrderBroadcast(const fbaeSL::SessionMsg &sessionMsg) override;
+    void totalOrderBroadcast(const fbae_SessionLayer::SessionMsg &sessionMsg) override;
     void terminate() override;
     std::string toString() override;
 };

--- a/src/AlgoLayer/Sequencer/SequencerMsg.h
+++ b/src/AlgoLayer/Sequencer/SequencerMsg.h
@@ -2,7 +2,6 @@
 
 #include "../../adaptCereal.h"
 #include "cereal/archives/binary.hpp"
-#include "cereal/types/string.hpp"
 #include "../../basicTypes.h"
 #include "../../SessionLayer/SessionLayerMsg.h"
 
@@ -24,7 +23,7 @@ namespace fbae_SequencerAlgoLayer
     {
         MsgId msgId{};
         rank_t senderPos{};
-        std::shared_ptr<fbaeSL::SessionBaseClass> sessionMsg;
+        fbae_SessionLayer::SessionMsg sessionMsg;
 
         // This method lets cereal know which data members to serialize
         template<class Archive>
@@ -33,6 +32,4 @@ namespace fbae_SequencerAlgoLayer
             archive(msgId, senderPos, sessionMsg); // serialize things by passing them to the archive
         }
     };
-
-
 }

--- a/src/Arguments.h
+++ b/src/Arguments.h
@@ -8,7 +8,7 @@
 
 // The following value has been found experimentally when filler field of SessionPerf has size 0
 // (See TEST(SerializationOverhead, CheckMinSizeClientMessageToBroadcast) in @testSerializationOverhead.cpp
-constexpr int minSizeClientMessageToBroadcast{40};
+constexpr int minSizeClientMessageToBroadcast{31};
 
 // Maximum length of a UDP packet
 constexpr size_t maxLength{65515};

--- a/src/SessionLayer/PerfMeasures/PerfMeasures.cpp
+++ b/src/SessionLayer/PerfMeasures/PerfMeasures.cpp
@@ -8,7 +8,7 @@
 #include "PerfMeasures.h"
 
 using namespace std;
-using namespace fbaeSL;
+using namespace fbae_SessionLayer;
 
 PerfMeasures::PerfMeasures(const Arguments &arguments, rank_t rank, std::unique_ptr<AlgoLayer> algoLayer)
         : SessionLayer{arguments, rank, std::move(algoLayer)}
@@ -21,17 +21,17 @@ void PerfMeasures::broadcastPerfMeasure() {
         cout << "PerfMeasures pos #" << static_cast<uint32_t>(getAlgoLayer()->getPosInBroadcastersGroup().value()) << " : Broadcast PerfMeasure (senderPos = " << static_cast<uint32_t>(getAlgoLayer()->getPosInBroadcastersGroup().value()) << " ; msgNum = " << numPerfMeasure << ")\n";
     if (numPerfMeasure == getArguments().getNbMsg()*getArguments().getWarmupCooldown()/100/2)
         measures.setStartTime();
-    auto sessionMsg = make_shared<SP>(SessionMsgId::PerfMeasure,
-                                      getAlgoLayer()->getPosInBroadcastersGroup().value(),
-                                      numPerfMeasure,
-                                      std::chrono::system_clock::now(),
-                                      std::string( getArguments().getSizeMsg() - minSizeClientMessageToBroadcast,
+    auto sessionMsg = make_shared<SessionPerf>(SessionMsgId::PerfMeasure,
+                                               getAlgoLayer()->getPosInBroadcastersGroup().value(),
+                                               numPerfMeasure,
+                                               std::chrono::system_clock::now(),
+                                               std::string( getArguments().getSizeMsg() - minSizeClientMessageToBroadcast,
                                             0));
     getAlgoLayer()->totalOrderBroadcast(sessionMsg);
     ++numPerfMeasure;
 }
 
-void PerfMeasures::callbackDeliver(rank_t senderPos, fbaeSL::SessionMsg msg) {
+void PerfMeasures::callbackDeliver(rank_t senderPos, fbae_SessionLayer::SessionMsg msg) {
     switch (msg->msgId)
     {
         using enum SessionMsgId;
@@ -125,8 +125,8 @@ void PerfMeasures::processFirstBroadcastMsg(rank_t senderPos) {
     }
 }
 
-void PerfMeasures::processPerfMeasureMsg(rank_t senderPos, const fbaeSL::SessionMsg &sessionMsg) {
-    auto nakedSessionMsg = dynamic_cast<SP*>(sessionMsg.get());
+void PerfMeasures::processPerfMeasureMsg(rank_t senderPos, const fbae_SessionLayer::SessionMsg &sessionMsg) {
+    auto nakedSessionMsg = dynamic_cast<SessionPerf*>(sessionMsg.get());
     if (getArguments().getVerbose())
         cout << "PerfMeasures pos #" << static_cast<uint32_t>(getAlgoLayer()->getPosInBroadcastersGroup().value()) << " : Deliver PerfMeasure from sender pos #" << static_cast<uint32_t>(senderPos) << " (senderPos = " << static_cast<uint32_t>(nakedSessionMsg->senderPos) << " ; msgNum = " << nakedSessionMsg->msgNum << ")\n";
     measures.addNbBytesDelivered(getArguments().getSizeMsg());
@@ -144,8 +144,8 @@ void PerfMeasures::processPerfMeasureMsg(rank_t senderPos, const fbaeSL::Session
     }
 }
 
-void PerfMeasures::processPerfResponseMsg(rank_t senderPos, const fbaeSL::SessionMsg &sessionMsg) {
-    auto nakedSessionMsg = dynamic_cast<SP*>(sessionMsg.get());
+void PerfMeasures::processPerfResponseMsg(rank_t senderPos, const fbae_SessionLayer::SessionMsg &sessionMsg) {
+    auto nakedSessionMsg = dynamic_cast<SessionPerf*>(sessionMsg.get());
     if (getArguments().getVerbose())
         cout << "PerfMeasures pos #" << static_cast<uint32_t>(getAlgoLayer()->getPosInBroadcastersGroup().value()) << " : Deliver PerfResponse from sender pos #" << static_cast<uint32_t>(senderPos) << " (perfMeasureSenderPos = " << static_cast<uint32_t>(nakedSessionMsg->senderPos) << " ; perfMeasureMsgNum = " << nakedSessionMsg->msgNum << ")\n";
     measures.addNbBytesDelivered(getArguments().getSizeMsg());

--- a/src/SessionLayer/PerfMeasures/PerfMeasures.h
+++ b/src/SessionLayer/PerfMeasures/PerfMeasures.h
@@ -15,7 +15,7 @@ class PerfMeasures : public SessionLayer {
 public:
     PerfMeasures(const Arguments &arguments, rank_t rank, std::unique_ptr<AlgoLayer> algoLayer);
 
-    void callbackDeliver(rank_t senderPos, fbaeSL::SessionMsg msg) override;
+    void callbackDeliver(rank_t senderPos, fbae_SessionLayer::SessionMsg msg) override;
     void callbackInitDone() override;
     void execute() override;
 
@@ -49,14 +49,14 @@ private:
      * @param senderPos Rank of message sender.
      * @param sessionMsg Message to process.
      */
-    void processPerfMeasureMsg(rank_t senderPos, const fbaeSL::SessionMsg &sessionMsg);
+    void processPerfMeasureMsg(rank_t senderPos, const fbae_SessionLayer::SessionMsg &sessionMsg);
 
     /**
      * @brief Called by @callbackDeliver to process @PerfMeasure message
      * @param senderPos Rank of message sender.
      * @param sessionMsg Message to process.
      */
-    void processPerfResponseMsg(rank_t senderPos, const fbaeSL::SessionMsg &sessionMsg);
+    void processPerfResponseMsg(rank_t senderPos, const fbae_SessionLayer::SessionMsg &sessionMsg);
 
     /**
      * @brief Thread to send PerfMessage at @Param::frequency per second.

--- a/src/SessionLayer/SessionLayer.h
+++ b/src/SessionLayer/SessionLayer.h
@@ -24,7 +24,7 @@ public:
      * @param seqNum Sequence number of @msg.
      * @param msg Message to be delivered.
      */
-    virtual void callbackDeliver(rank_t senderPos, fbaeSL::SessionMsg msg) = 0;
+    virtual void callbackDeliver(rank_t senderPos, fbae_SessionLayer::SessionMsg msg) = 0;
 
     /**
      * @brief Callback called by @AlgoLayer when @AlgoLayer is initialized locally.

--- a/src/basicTypes.h
+++ b/src/basicTypes.h
@@ -2,8 +2,8 @@
 // Created by simatic on 1/31/24.
 //
 
-#ifndef FBAE_BASICTYPES_H
-#define FBAE_BASICTYPES_H
+#ifndef FBAE_BASIC_TYPES_H
+#define FBAE_BASIC_TYPES_H
 
 #include <cstdint>
 
@@ -17,4 +17,4 @@ using rank_t = uint8_t;
  */
 using MsgId_t = uint8_t;
 
-#endif //FBAE_BASICTYPES_H
+#endif //FBAE_BASIC_TYPES_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,7 +53,7 @@ int main(int argc, char* argv[])
             "m:maxBatchSize number_of_messages \t [optional] Maximum size of batch of messages (if specified algorithm allows batch of messages; By default, maxBatchSize is unlimited)",
             "n:nbMsg number \t Number of messages to be sent",
             "r:rank rank_number \t Rank of process in site file (if 99, all algorithm participants are executed within threads in current process)",
-            "s:size size_in_bytes \t Size of messages sent by a client (must be in interval [40,65515])",
+            "s:size size_in_bytes \t Size of messages sent by a client (must be in interval [31,65515])",
             "S:site siteFile_name \t Name (including path) of the sites file to be used",
             "v|verbose \t [optional] Verbose display required",
             "w:warmupCooldown number \t [optional] Number in [0,99] representing percentage of PerfMessage sessionLayer messages which will be considered as part of warmup phase or cool down phase and thus will not be measured for ping (By default, percentage is 0%)"

--- a/src/msgTemplates.h
+++ b/src/msgTemplates.h
@@ -2,7 +2,6 @@
 
 #include "adaptCereal.h"
 #include <cereal/archives/binary.hpp>
-#include <cereal/types/string.hpp>
 
 /**
  * @brief Returns structure @S deserialized from @msgString

--- a/tests/AlgoLayer/testBBOBB.cpp
+++ b/tests/AlgoLayer/testBBOBB.cpp
@@ -12,7 +12,7 @@
 namespace fbae_test_BBOBB {
 
     using namespace std;
-    using namespace fbaeSL;
+    using namespace fbae_SessionLayer;
 
     TEST(BBOBB, ExecuteWith4SitesAndRank0) {
         constexpr auto nbSites = 4;
@@ -47,7 +47,7 @@ namespace fbae_test_BBOBB {
         EXPECT_EQ(0, stepMsg.step);
         EXPECT_EQ(1, stepMsg.batchesBroadcast.size()); // Just 1 batch message
         EXPECT_EQ(myRank, stepMsg.batchesBroadcast[0].senderPos); // Sender of this batch messages is 0
-        EXPECT_EQ(fbaeSL::SessionMsgId::FirstBroadcast, stepMsg.batchesBroadcast[0].batchSessionMsg[0]->msgId);
+        EXPECT_EQ(fbae_SessionLayer::SessionMsgId::FirstBroadcast, stepMsg.batchesBroadcast[0].batchSessionMsg[0]->msgId);
 
         // Check @AlgoLayer:broadcastersGroup is correct
         EXPECT_EQ(nbSites, algoLayerRaw->getBroadcastersGroup().size());
@@ -101,7 +101,7 @@ namespace fbae_test_BBOBB {
         EXPECT_EQ(0, stepMsg.step);
         EXPECT_EQ(1, stepMsg.batchesBroadcast.size()); // Just 1 batch message
         EXPECT_EQ(myRank, stepMsg.batchesBroadcast[0].senderPos); // Sender of this batch messages is 0
-        EXPECT_EQ(fbaeSL::SessionMsgId::FirstBroadcast, stepMsg.batchesBroadcast[0].batchSessionMsg[0]->msgId);
+        EXPECT_EQ(fbae_SessionLayer::SessionMsgId::FirstBroadcast, stepMsg.batchesBroadcast[0].batchSessionMsg[0]->msgId);
 
         // Check @AlgoLayer:broadcastersGroup is correct
         EXPECT_EQ(nbSites, algoLayerRaw->getBroadcastersGroup().size());
@@ -138,8 +138,8 @@ namespace fbae_test_BBOBB {
 
         algoLayerRaw->execute();
         commLayerRaw->getSent().clear(); // We clear FirstBroadcast information which we already tested in previous execute() tests
-        auto sessionMsg = make_shared<ST>(SessionMsgId::TestMessage,
-                                          "A");
+        auto sessionMsg = make_shared<SessionTest>(SessionMsgId::TestMessage,
+                                                   "A");
         algoLayerRaw->totalOrderBroadcast(sessionMsg);
 
         // Check that no message was sent as message is stored in @AlgoLayer::batchWaitingSessionMsg
@@ -163,10 +163,10 @@ namespace fbae_test_BBOBB {
         algoLayerRaw->execute();
         commLayerRaw->getSent().clear(); // We clear FirstBroadcast information which we already tested in previous execute() tests
         // Prepare Step message to be received in current wave from sender 0
-        auto sessionMsgA = make_shared<ST>(
+        auto sessionMsgA = make_shared<SessionTest>(
                 SessionMsgId::TestMessage,
                 "A");
-        auto sessionMsgB = make_shared<ST>(
+        auto sessionMsgB = make_shared<SessionTest>(
                 SessionMsgId::TestMessage,
                 "B");
         std::vector<SessionMsg > v{sessionMsgA, sessionMsgB};
@@ -184,14 +184,14 @@ namespace fbae_test_BBOBB {
         EXPECT_EQ(3, sessionStub.getDelivered().size());
         EXPECT_EQ(0, sessionStub.getDelivered()[0].first);
         EXPECT_EQ(sessionMsgA->msgId, sessionStub.getDelivered()[0].second->msgId);
-        auto nakedA = dynamic_cast<ST*>(sessionStub.getDelivered()[0].second.get());
+        auto nakedA = dynamic_cast<SessionTest*>(sessionStub.getDelivered()[0].second.get());
         EXPECT_EQ(sessionMsgA->payload, nakedA->payload);
         EXPECT_EQ(0, sessionStub.getDelivered()[1].first);
         EXPECT_EQ(sessionMsgB->msgId, sessionStub.getDelivered()[1].second->msgId);
-        auto nakedB = dynamic_cast<ST*>(sessionStub.getDelivered()[1].second.get());
+        auto nakedB = dynamic_cast<SessionTest*>(sessionStub.getDelivered()[1].second.get());
         EXPECT_EQ(sessionMsgB->payload, nakedB->payload);
         EXPECT_EQ(myRank, sessionStub.getDelivered()[2].first);
-        EXPECT_EQ(fbaeSL::SessionMsgId::FirstBroadcast, sessionStub.getDelivered()[2].second->msgId);
+        EXPECT_EQ(fbae_SessionLayer::SessionMsgId::FirstBroadcast, sessionStub.getDelivered()[2].second->msgId);
 
         // Check a new Step message has been sent
         EXPECT_EQ(1, commLayerRaw->getSent().size());
@@ -221,10 +221,10 @@ namespace fbae_test_BBOBB {
         algoLayerRaw->execute();
         commLayerRaw->getSent().clear(); // We clear FirstBroadcast information which we already tested in previous execute() tests
         // Prepare Step message to be received in current wave from sender 0
-        auto sessionMsgC = make_shared<ST>(
+        auto sessionMsgC = make_shared<SessionTest>(
                 SessionMsgId::TestMessage,
                 "C");
-        auto sessionMsgD = make_shared<ST>(
+        auto sessionMsgD = make_shared<SessionTest>(
                 SessionMsgId::TestMessage,
                 "D");
         std::vector<SessionMsg> vWave1{sessionMsgC, sessionMsgD};
@@ -243,10 +243,10 @@ namespace fbae_test_BBOBB {
         EXPECT_EQ(0, sessionStub.getDelivered().size());
 
         // Now prepare Step message to be received in current wave from sender 0
-        auto sessionMsgA = make_shared<ST>(
+        auto sessionMsgA = make_shared<SessionTest>(
                 SessionMsgId::TestMessage,
                 "A");
-        auto sessionMsgB = make_shared<ST>(
+        auto sessionMsgB = make_shared<SessionTest>(
                 SessionMsgId::TestMessage,
                 "B");
         std::vector<SessionMsg > v{sessionMsgA, sessionMsgB};
@@ -264,21 +264,21 @@ namespace fbae_test_BBOBB {
         EXPECT_EQ(5, sessionStub.getDelivered().size());
         EXPECT_EQ(0, sessionStub.getDelivered()[0].first);
         EXPECT_EQ(sessionMsgA->msgId, sessionStub.getDelivered()[0].second->msgId);
-        auto nakedA = dynamic_cast<ST*>(sessionStub.getDelivered()[0].second.get());
+        auto nakedA = dynamic_cast<SessionTest*>(sessionStub.getDelivered()[0].second.get());
         EXPECT_EQ(sessionMsgA->payload, nakedA->payload);
         EXPECT_EQ(0, sessionStub.getDelivered()[1].first);
         EXPECT_EQ(sessionMsgB->msgId, sessionStub.getDelivered()[1].second->msgId);
-        auto nakedB = dynamic_cast<ST*>(sessionStub.getDelivered()[1].second.get());
+        auto nakedB = dynamic_cast<SessionTest*>(sessionStub.getDelivered()[1].second.get());
         EXPECT_EQ(sessionMsgB->payload, nakedB->payload);
         EXPECT_EQ(myRank, sessionStub.getDelivered()[2].first);
-        EXPECT_EQ(fbaeSL::SessionMsgId::FirstBroadcast, sessionStub.getDelivered()[2].second->msgId);
+        EXPECT_EQ(fbae_SessionLayer::SessionMsgId::FirstBroadcast, sessionStub.getDelivered()[2].second->msgId);
         EXPECT_EQ(0, sessionStub.getDelivered()[3].first);
         EXPECT_EQ(sessionMsgC->msgId, sessionStub.getDelivered()[3].second->msgId);
-        auto nakedC = dynamic_cast<ST*>(sessionStub.getDelivered()[3].second.get());
+        auto nakedC = dynamic_cast<SessionTest*>(sessionStub.getDelivered()[3].second.get());
         EXPECT_EQ(sessionMsgC->payload, nakedC->payload);
         EXPECT_EQ(0, sessionStub.getDelivered()[4].first);
         EXPECT_EQ(sessionMsgD->msgId, sessionStub.getDelivered()[4].second->msgId);
-        auto nakedD = dynamic_cast<ST*>(sessionStub.getDelivered()[4].second.get());
+        auto nakedD = dynamic_cast<SessionTest*>(sessionStub.getDelivered()[4].second.get());
         EXPECT_EQ(sessionMsgD->payload, nakedD->payload);
 
         // Check two new Step messages have been sent
@@ -320,10 +320,10 @@ namespace fbae_test_BBOBB {
         algoLayerRaw->execute();
         commLayerRaw->getSent().clear(); // We clear FirstBroadcast information which we already tested in previous execute() tests
         // Prepare Step message to be received in incorrect wave from sender 0
-        auto sessionMsgE = make_shared<ST>(
+        auto sessionMsgE = make_shared<SessionTest>(
                 SessionMsgId::TestMessage,
                 "E");
-        auto sessionMsgF = make_shared<ST>(
+        auto sessionMsgF = make_shared<SessionTest>(
                 SessionMsgId::TestMessage,
                 "E");
         std::vector<SessionMsg> vWave2{sessionMsgE, sessionMsgF};

--- a/tests/AlgoLayer/testSequencer.cpp
+++ b/tests/AlgoLayer/testSequencer.cpp
@@ -13,7 +13,7 @@
 namespace fbae_test_Sequencer {
 
     using namespace std;
-    using namespace fbaeSL;
+    using namespace fbae_SessionLayer;
 
     TEST(Sequencer, SequencerExecute) {
         constexpr auto nbSites = 4;
@@ -84,7 +84,7 @@ namespace fbae_test_Sequencer {
         auto broadcastMsg{deserializeStruct<fbae_SequencerAlgoLayer::StructBroadcastMessage>(std::move(commLayerRaw->getSent()[0].second))};
         EXPECT_EQ(fbae_SequencerAlgoLayer::MsgId::BroadcastRequest, broadcastMsg.msgId);
         EXPECT_EQ(myRank-1, broadcastMsg.senderPos); // myRank-1 because senderPos is 1 less than senderRank
-        EXPECT_EQ(fbaeSL::SessionMsgId::FirstBroadcast, broadcastMsg.sessionMsg->msgId);
+        EXPECT_EQ(fbae_SessionLayer::SessionMsgId::FirstBroadcast, broadcastMsg.sessionMsg->msgId);
 
         // Check @AlgoLayer:broadcastersGroup is correct
         EXPECT_EQ(nbSites - 1, algoLayerRaw->getBroadcastersGroup().size());
@@ -115,8 +115,8 @@ namespace fbae_test_Sequencer {
 
         algoLayerRaw->execute();
         commLayerRaw->getSent().clear(); // We clear FirstBroadcast information which we already tested in previous execute() tests
-        auto sessionMsg = make_shared<ST>(SessionMsgId::TestMessage,
-                                          "A");
+        auto sessionMsg = make_shared<SessionTest>(SessionMsgId::TestMessage,
+                                                   "A");
         algoLayerRaw->totalOrderBroadcast(sessionMsg);
 
         // Check that 1 message was sent
@@ -128,7 +128,7 @@ namespace fbae_test_Sequencer {
         EXPECT_EQ(fbae_SequencerAlgoLayer::MsgId::BroadcastRequest, broadcastRequestMsg.msgId);
         EXPECT_EQ(myRank-1, broadcastRequestMsg.senderPos); // myRank-1 because senderPos is 1 less than senderRank
         EXPECT_EQ(sessionMsg->msgId, broadcastRequestMsg.sessionMsg->msgId);
-        auto naked = dynamic_cast<ST*>(broadcastRequestMsg.sessionMsg.get());
+        auto naked = dynamic_cast<SessionTest*>(broadcastRequestMsg.sessionMsg.get());
         EXPECT_EQ(sessionMsg->payload, naked->payload);
 
         // Check that no message is delivered
@@ -148,8 +148,8 @@ namespace fbae_test_Sequencer {
 
         algoLayerRaw->execute();
         commLayerRaw->getSent().clear(); // We clear FirstBroadcast information which we already tested in previous execute() tests
-        auto sessionMsg = make_shared<ST>(SessionMsgId::TestMessage,
-                                          "A");
+        auto sessionMsg = make_shared<SessionTest>(SessionMsgId::TestMessage,
+                                                   "A");
         constexpr rank_t senderPos = 42;
         auto algoMsgAsString {serializeStruct<fbae_SequencerAlgoLayer::StructBroadcastMessage>(fbae_SequencerAlgoLayer::StructBroadcastMessage{
             fbae_SequencerAlgoLayer::MsgId::BroadcastRequest,
@@ -171,7 +171,7 @@ namespace fbae_test_Sequencer {
         EXPECT_EQ(fbae_SequencerAlgoLayer::MsgId::Broadcast, broadcastMsg.msgId);
         EXPECT_EQ(senderPos, broadcastMsg.senderPos);
         EXPECT_EQ(sessionMsg->msgId, broadcastMsg.sessionMsg->msgId);
-        auto naked = dynamic_cast<ST*>(broadcastMsg.sessionMsg.get());
+        auto naked = dynamic_cast<SessionTest*>(broadcastMsg.sessionMsg.get());
         EXPECT_EQ(sessionMsg->payload, naked->payload);
 
         // Check that no message is delivered
@@ -191,8 +191,8 @@ namespace fbae_test_Sequencer {
 
         algoLayerRaw->execute();
         commLayerRaw->getSent().clear(); // We clear FirstBroadcast information which we already tested in previous execute() tests
-        auto sessionMsg = make_shared<ST>(SessionMsgId::TestMessage,
-                                          "A");
+        auto sessionMsg = make_shared<SessionTest>(SessionMsgId::TestMessage,
+                                                   "A");
         constexpr rank_t senderPos = 42;
         auto algoMsgAsString {serializeStruct<fbae_SequencerAlgoLayer::StructBroadcastMessage>(fbae_SequencerAlgoLayer::StructBroadcastMessage{
             fbae_SequencerAlgoLayer::MsgId::Broadcast,
@@ -209,7 +209,7 @@ namespace fbae_test_Sequencer {
         EXPECT_EQ(senderPos, sessionStub.getDelivered()[0].first);
         // Check contents of this message
         EXPECT_EQ(sessionMsg->msgId, sessionStub.getDelivered()[0].second->msgId);
-        auto naked = dynamic_cast<ST*>(sessionStub.getDelivered()[0].second.get());
+        auto naked = dynamic_cast<SessionTest*>(sessionStub.getDelivered()[0].second.get());
         EXPECT_EQ(sessionMsg->payload, naked->payload);
     }
 

--- a/tests/SessionLayer/SessionStub.cpp
+++ b/tests/SessionLayer/SessionStub.cpp
@@ -11,7 +11,7 @@ SessionStub::SessionStub(const Arguments &arguments, rank_t rank, std::unique_pt
 {
 }
 
-void SessionStub::callbackDeliver(rank_t senderPos, fbaeSL::SessionMsg msg) {
+void SessionStub::callbackDeliver(rank_t senderPos, fbae_SessionLayer::SessionMsg msg) {
     delivered.emplace_back(senderPos, msg);
 }
 
@@ -19,7 +19,7 @@ void SessionStub::callbackInitDone() {
     callbackInitDoneCalled = true;
     // We simulate the sending fo FirstBroadcast as done in @PerfMeasures class.
     if (getAlgoLayer()->isBroadcastingMessages()) {
-        auto sessionMsg = std::make_shared<fbaeSL::SessionFirstBroadcast>(fbaeSL::SessionMsgId::FirstBroadcast);
+        auto sessionMsg = std::make_shared<fbae_SessionLayer::SessionFirstBroadcast>(fbae_SessionLayer::SessionMsgId::FirstBroadcast);
         getAlgoLayer()->totalOrderBroadcast(sessionMsg);
     }
 }
@@ -29,7 +29,7 @@ void SessionStub::execute() {
     assert(false);
 }
 
-std::vector<std::pair<rank_t, fbaeSL::SessionMsg>> & SessionStub::getDelivered() {
+std::vector<std::pair<rank_t, fbae_SessionLayer::SessionMsg>> & SessionStub::getDelivered() {
     return delivered;
 }
 

--- a/tests/SessionLayer/SessionStub.h
+++ b/tests/SessionLayer/SessionStub.h
@@ -12,16 +12,16 @@ class SessionStub : public SessionLayer {
 public:
     SessionStub(const Arguments &arguments, rank_t rank, std::unique_ptr<AlgoLayer> algoLayer);
 
-    void callbackDeliver(rank_t senderPos, fbaeSL::SessionMsg msg) override;
+    void callbackDeliver(rank_t senderPos, fbae_SessionLayer::SessionMsg msg) override;
     void callbackInitDone() override;
     void execute() override;
-    [[nodiscard]] std::vector<std::pair<rank_t, fbaeSL::SessionMsg>> & getDelivered();
+    [[nodiscard]] std::vector<std::pair<rank_t, fbae_SessionLayer::SessionMsg>> & getDelivered();
     [[nodiscard]] bool isCallbackInitDoneCalled() const;
 private:
     /**
      * @brief Vector of [sender,msg] for which @callbackDeliver() method was called
      */
-    std::vector<std::pair<rank_t, fbaeSL::SessionMsg>> delivered;
+    std::vector<std::pair<rank_t, fbae_SessionLayer::SessionMsg>> delivered;
 
     /**
      * @brief Indicates whether @SessionLayer::callbackInitDone called or not.


### PR DESCRIPTION
- To suppress compilation warnings:
    - We define serialize() method as private method
- To reduce overhead of polymorphic serialization:
    - We register types with very short names (by using `CEREAL_REGISTER_TYPE_WITH_NAME` instead of ``CEREAL_REGISTER_TYPE`) in order to use names as short as possible in serialized messages.
    - Doing so, we are able to use again normal names for `fbae_SessionLayer` namespace and `SessionPerf` and `SessionTest` message.